### PR TITLE
Repaired TemplateURL

### DIFF
--- a/templates/cribl-single-arm64-new-vpc-logging.template.yaml
+++ b/templates/cribl-single-arm64-new-vpc-logging.template.yaml
@@ -322,7 +322,7 @@ Resources:
     Type: AWS::CloudFormation::Stack
     Properties:
       TemplateURL: !Sub 
-        - https://${S3Bucket}.s3.${QSS3BucketRegion}.${AWS::URLSuffix}/${QSS3KeyPrefix}/cribl-single-arm64.workload.template.yaml
+        - https://${S3Bucket}.s3.${QSS3BucketRegion}.${AWS::URLSuffix}/${S3Bucket}-cribl-logstream/templates/cribl-single-arm64.workload.template.yaml
         - S3Bucket: !If
             - UsingDefaultBucket
             - !Sub '${QSS3BucketName}-cribl-logstream-${QSS3BucketRegion}'


### PR DESCRIPTION
Fixed the URL to point to the correct template directory.

*Issue #, if available:*

*Description of changes:*
Replaced the Template URL for the CriblDeploy resource to fix the empty Resource.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
