### PR TITLE
Repaired CriblDeploy Resource

### DIFF
--- a/templates/cribl-single-x86-new-vpc-logging.template.yaml
+++ b/templates/cribl-single-x86-new-vpc-logging.template.yaml
@@ -138,7 +138,7 @@ Parameters:
     AllowedPattern: ^([0-9a-zA-Z-.]+/)*$
     ConstraintDescription: The Quick Start S3 key prefix can include numbers, lowercase letters,
       uppercase letters, hyphens (-), and forward slashes (/).
-    Default: quickstart-cribl-logstream/
+    Default: templates/
     Description: S3 key prefix that is used to simulate a directory for your copy of the 
       Quick Start assets. Keep the default prefix unless you are customizing 
       the template. Changing this prefix updates code references to point to 
@@ -322,11 +322,11 @@ Resources:
     Type: AWS::CloudFormation::Stack
     Properties:
       TemplateURL: !Sub 
-        - https://${S3Bucket}.s3.${QSS3BucketRegion}.${AWS::URLSuffix}/${QSS3KeyPrefix}/cribl-single-x86.workload.template.yaml
-        - S3Bucket: !If
-            - UsingDefaultBucket
-            - !Sub '${QSS3BucketName}-cribl-logstream-${QSS3BucketRegion}'
-            - !Ref QSS3BucketName
+      - https://${S3Bucket}.s3.${QSS3BucketRegion}.${AWS::URLSuffix}/${S3Bucket}-cribl-logstream/${QSS3KeyPrefix}/cribl-single-x86.workload.template.yaml
+      - S3Bucket: !If
+          - UsingDefaultBucket
+          - !Sub '${QSS3BucketName}'
+          - !Ref QSS3BucketName
       Parameters:
         webAccessCidr: !Ref webAccessCidr
         vpcId: !GetAtt


### PR DESCRIPTION
Replaced the URL for the template to repair issue on deployment. Also replaced prefix for templates instead of the default cribl-logstream.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
